### PR TITLE
Add links to 5 open-source YC startups

### DIFF
--- a/src/scrapper/repos.yaml
+++ b/src/scrapper/repos.yaml
@@ -13,4 +13,8 @@ groups:
       - https://api.github.com/repos/stripe/stripe-python
       - https://api.github.com/repos/unslothai/unsloth
       - https://api.github.com/repos/srcbookdev/srcbook
-      
+      - https://api.github.com/repos/supabase/supabase
+      - https://api.github.com/repos/FortAwesome/Font-Awesome
+      - https://api.github.com/repos/reworkd/AgentGPT
+      - https://api.github.com/repos/mattermost/mattermost
+      - https://api.github.com/repos/influxdata/influxdb


### PR DESCRIPTION
### Description
Added links to 5 open-source YC startups to the `src/scraper/repos.yaml` file.

### Changes Made
- Added the following repository links under the `YC` type:
  - https://api.github.com/repos/supabase/supabase
  - https://api.github.com/repos/FortAwesome/Font-Awesome
  - https://api.github.com/repos/reworkd/AgentGPT
  - https://api.github.com/repos/mattermost/mattermost
  - https://api.github.com/repos/influxdata/influxdb

### Issue Reference
This pull request addresses issue #9.
